### PR TITLE
refactor: extract color scheme legend into a TagColorComponent

### DIFF
--- a/assets/css/_exercise-gestion.scss
+++ b/assets/css/_exercise-gestion.scss
@@ -19,47 +19,6 @@ h1 {
   }
 }
 
-.legend-wrapper {
-  font-weight: 200;
-  margin-top: 20px;
-  margin-bottom: 20px;
-
-  .legend__title {
-    margin-bottom: 10px;
-    text-decoration: underline;
-  }
-
-  > .legend {
-    &:not(:last-child) {
-      margin-bottom: 7px;
-    }
-
-    &:before {
-      content: "";
-      position: relative;
-      width: 10px;
-      height: 10px;
-      @include border-radius(50%);
-      display: inline-block;
-      vertical-align: middle;
-      margin-right: 7px;
-    }
-  }
-
-
-  .legend--validated:before {
-    background-color: $SECONDARY_COLOR;
-  }
-
-  .legend--not-validated:before {
-    background-color: lighten($RED, 10);
-  }
-
-  .legend--deprecated:before {
-    background-color: lighten($ORANGE, 13);
-  }
-}
-
 .content {
   background-color: white;
   border-radius: 4px;

--- a/components/Gestion/ExerciseForm.vue
+++ b/components/Gestion/ExerciseForm.vue
@@ -57,21 +57,7 @@
                                                                    class="link">ici</span> !
     </p>
 
-    <div class="legend-wrapper">
-      <div class="legend__title">
-        Code couleur
-      </div>
-      <div class="legend legend--validated">
-        valide
-      </div>
-      <div class="legend legend--deprecated">
-        obsolète
-      </div>
-      <div class="legend legend--not-validated">
-        non valide
-      </div>
-    </div>
-
+    <TagColorLegend/>
 
     <transition name="fade">
       <ValidationObserver class="validation__tag" ref="observer3" tag="form" v-show="showNewTagLayout"
@@ -193,10 +179,11 @@
   import CustomSelect from "~/components/Input/CustomSelect.vue";
   import jsonFormData from 'json-form-data';
   import ExerciseFormMixins from "~/components/Mixins/ExerciseFormMixins";
+  import TagColorLegend from "~/components/Tag/TagColorLegend.vue";
 
   const debounce = require('lodash.debounce');
   @Component({
-    components: {CustomSelect, ValidationObserver, ValidationProvider, RichTextEditor, Tag, Icon}
+    components: {TagColorLegend, CustomSelect, ValidationObserver, ValidationProvider, RichTextEditor, Tag, Icon}
   })
   export default class ExerciseForm extends Mixins(FilterPanelMixins, ExerciseFormMixins) {
     @Prop({type: Object, default: undefined}) exercise!: Exercise | undefined;

--- a/components/Gestion/FavoriteForm.vue
+++ b/components/Gestion/FavoriteForm.vue
@@ -45,20 +45,7 @@
            @deleteTag="deleteTag($event, tag)"/>
     </div>
 
-    <div class="legend-wrapper">
-      <div class="legend__title">
-        Code couleur
-      </div>
-      <div class="legend legend--validated">
-        valide
-      </div>
-      <div class="legend legend--deprecated">
-        obsolète
-      </div>
-      <div class="legend legend--not-validated">
-        non valide
-      </div>
-    </div>
+    <TagColorLegend/>
 
     <div class="cta__validate--wrapper">
       <button @click="validateBeforeSubmit" class="button--ternary-color-reverse button__validate">
@@ -76,11 +63,11 @@
   import FavoriteFormMixins from "~/components/Mixins/FavoriteFormMixins";
   import {Configuration, CreateConfigurationRequest, SelectedTag, UpdateConfigurationRequest} from "../../types";
   import {ValidationObserver, ValidationProvider} from "vee-validate";
-  import qs from "qs";
   import Tag from "../Tag/Tag.vue";
+  import TagColorLegend from "~/components/Tag/TagColorLegend.vue";
 
   @Component({
-    components: {Tag, ValidationProvider, ValidationObserver}
+    components: {TagColorLegend, Tag, ValidationProvider, ValidationObserver}
   })
   export default class FavoriteForm extends Mixins(FilterPanelMixins, FavoriteFormMixins) {
 

--- a/components/Tag/TagColorLegend.vue
+++ b/components/Tag/TagColorLegend.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="legend-wrapper">
+    <div class="legend__title">
+      Code couleur
+    </div>
+    <div class="legend legend--validated">
+      valide
+    </div>
+    <div class="legend legend--deprecated">
+      obsolète
+    </div>
+    <div class="legend legend--not-validated">
+      non valide
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+  import {Component, Vue} from "vue-property-decorator";
+
+  @Component
+  export default class TagColorLegend extends Vue {
+  }
+</script>
+
+<style lang="scss" scoped>
+  @import "assets/css/variables";
+  @import "assets/css/function";
+
+  .legend-wrapper {
+    font-weight: 200;
+    margin-top: 20px;
+    margin-bottom: 20px;
+
+    .legend__title {
+      margin-bottom: 10px;
+      text-decoration: underline;
+    }
+
+    > .legend {
+      &:not(:last-child) {
+        margin-bottom: 7px;
+      }
+
+      &:before {
+        content: "";
+        position: relative;
+        width: 10px;
+        height: 10px;
+        @include border-radius(50%);
+        display: inline-block;
+        vertical-align: middle;
+        margin-right: 7px;
+      }
+    }
+
+
+    .legend--validated:before {
+      background-color: $SECONDARY_COLOR;
+    }
+
+    .legend--not-validated:before {
+      background-color: lighten($RED, 10);
+    }
+
+    .legend--deprecated:before {
+      background-color: lighten($ORANGE, 13);
+    }
+  }
+</style>


### PR DESCRIPTION
**New**

- Create new component containing the color scheme of a tag

**refactoring**

- Remove legend style from exercise_gestion.scss file and move it into the new component
- Replace html legend occurence by the new component